### PR TITLE
INFRA-6343 - duplicate concept member exception after the db change t…

### DIFF
--- a/jpa-services/src/main/java/org/ihtsdo/otf/refset/jpa/services/RefsetServiceJpa.java
+++ b/jpa-services/src/main/java/org/ihtsdo/otf/refset/jpa/services/RefsetServiceJpa.java
@@ -2823,6 +2823,12 @@ public class RefsetServiceJpa extends ReleaseServiceJpa
     //
     syncNotes(originRefset.getNotes(), currentRefset.getNotes());
 
+
+    // see RTT-6343
+    // updateRefset without removing the members will cause a duplicate exception
+    // in the database
+    currentRefset.setMembers(null);
+    
     //
     // at the end, originRefset should have exactly the right members
     // attached to it (for indexing)


### PR DESCRIPTION
…o speed up the query

After adding the index to the database for table concept_refset_member_synonyms_aud there was an error with duplicate concept member when committing the transaction.