### PR TITLE
Revert "Bump jersey-common from 2.29 to 2.34 in /parent"

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -47,7 +47,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
-    <jersey.core.version>2.34</jersey.core.version>
+    <jersey.core.version>2.29</jersey.core.version>
     <jersey.media.version>2.29</jersey.media.version>
     <junit.version>4.13.1</junit.version>
     <lucene.version>5.5.5</lucene.version>


### PR DESCRIPTION
Changing jersey org.glassfish.jersey.core causes issues at application start up.  Reverting until versions can be sorted resolved.